### PR TITLE
Add stream control frame decoding (0x04, 0x05, 0x11-0x13, 0x15-0x17)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ "main" ]
   pull_request:
-    branches: [ "main" ]
+    branches: ["*"]
 
 env:
   CARGO_TERM_COLOR: always

--- a/src/quic/frames/mod.rs
+++ b/src/quic/frames/mod.rs
@@ -57,6 +57,21 @@ impl Frame {
         match frame_type {
             0x00 => Ok(Frame::Padding),
             0x01 => Ok(Frame::Ping),
+            0x04 => {
+                if buf.remaining() == 0 {
+                    return Err(FrameError::InvalidVarInt);
+                }
+                let stream_id = var_int::read(buf).ok_or(FrameError::InvalidVarInt)?;
+                if buf.remaining() == 0 {
+                    return Err(FrameError::InvalidVarInt);
+                }
+                let error_code = var_int::read(buf).ok_or(FrameError::InvalidVarInt)?;
+                if buf.remaining() == 0 {
+                    return Err(FrameError::InvalidVarInt);
+                }
+                let final_size = var_int::read(buf).ok_or(FrameError::InvalidVarInt)?;
+                Ok(Frame::ResetStream(stream_id, error_code, final_size))
+            }
             0x10 => {
                 if buf.is_empty() {
                     return Err(FrameError::InvalidVarInt);
@@ -254,6 +269,23 @@ mod tests {
         // Type 0x1d, error_code=0x0a, reason_phrase_length=5, but only 2 bytes of reason
         let mut buf = Bytes::from_static(&[0x1d, 0x0a, 0x05, b'e', b'r']);
         assert_eq!(Frame::decode(&mut buf), Err(FrameError::BufferTooShort));
+    }
+
+    #[test]
+    fn test_decode_reset_stream_frame() {
+        // Type 0x04, stream_id=1, error_code=2, final_size=3
+        let mut buf = Bytes::from_static(&[0x04, 0x01, 0x02, 0x03]);
+        assert_eq!(
+            Frame::decode(&mut buf),
+            Ok(Frame::ResetStream(1, 2, 3))
+        );
+    }
+
+    #[test]
+    fn test_decode_reset_stream_frame_buffer_too_short() {
+        // Type 0x04, stream_id=1 but missing error_code and final_size
+        let mut buf = Bytes::from_static(&[0x04, 0x01]);
+        assert_eq!(Frame::decode(&mut buf), Err(FrameError::InvalidVarInt));
     }
 
     #[test]

--- a/src/quic/frames/mod.rs
+++ b/src/quic/frames/mod.rs
@@ -248,7 +248,6 @@ mod tests {
     #[test]
     fn test_decode_path_challenge() {
         let mut buf = Bytes::from_static(&[0x1a, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08]);
-        let mut buf = Bytes::from_static(&[0x1a, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08]);
         assert_eq!(
             Frame::decode(&mut buf),
             Ok(Frame::PathChallenge([

--- a/src/quic/frames/mod.rs
+++ b/src/quic/frames/mod.rs
@@ -171,6 +171,21 @@ mod tests {
     #[test]
     fn test_decode_path_challenge_buffer_too_short() {
         let mut buf = Bytes::from_static(&[0x1a, 0x01, 0x02]);
+        assert_eq!(
+            Frame::decode(&mut buf),
+            Ok(Frame::ConnectionClose(
+                0x0a,
+                None,
+                5,
+                Bytes::from_static(b"error")
+            ))
+        );
+    }
+
+    #[test]
+    fn test_decode_connection_close_app_buffer_too_short() {
+        // Type 0x1d, error_code=0x0a, reason_phrase_length=5, but only 2 bytes of reason
+        let mut buf = Bytes::from_static(&[0x1d, 0x0a, 0x05, b'e', b'r']);
         assert_eq!(Frame::decode(&mut buf), Err(FrameError::BufferTooShort));
     }
 
@@ -188,70 +203,6 @@ mod tests {
     #[test]
     fn test_decode_path_response_buffer_too_short() {
         let mut buf = Bytes::from_static(&[0x1b, 0x01, 0x02]);
-        assert_eq!(Frame::decode(&mut buf), Err(FrameError::BufferTooShort));
-    }
-
-    #[test]
-    fn test_decode_connection_close_quic_empty_reason() {
-        // Type 0x1c, error_code=0x00, frame_type=0x00, reason_phrase_length=0
-        let mut buf = Bytes::from_static(&[0x1c, 0x00, 0x00, 0x00]);
-        assert_eq!(
-            Frame::decode(&mut buf),
-            Ok(Frame::ConnectionClose(0x00, Some(0x00), 0, Bytes::new()))
-        );
-    }
-
-    #[test]
-    fn test_decode_connection_close_quic_with_reason() {
-        // Type 0x1c, error_code=0x0a, frame_type=0x01, reason_phrase_length=5, reason="error"
-        let mut buf = Bytes::from_static(&[0x1c, 0x0a, 0x01, 0x05, b'e', b'r', b'r', b'o', b'r']);
-        assert_eq!(
-            Frame::decode(&mut buf),
-            Ok(Frame::ConnectionClose(
-                0x0a,
-                Some(0x01),
-                5,
-                Bytes::from_static(b"error")
-            ))
-        );
-    }
-
-    #[test]
-    fn test_decode_connection_close_quic_buffer_too_short() {
-        // Type 0x1c, error_code=0x0a, frame_type=0x01, reason_phrase_length=5, but only 2 bytes of reason
-        let mut buf = Bytes::from_static(&[0x1c, 0x0a, 0x01, 0x05, b'e', b'r']);
-        assert_eq!(Frame::decode(&mut buf), Err(FrameError::BufferTooShort));
-    }
-
-    #[test]
-    fn test_decode_connection_close_app_empty_reason() {
-        // Type 0x1d, error_code=0x00, reason_phrase_length=0
-        let mut buf = Bytes::from_static(&[0x1d, 0x00, 0x00]);
-        assert_eq!(
-            Frame::decode(&mut buf),
-            Ok(Frame::ConnectionClose(0x00, None, 0, Bytes::new()))
-        );
-    }
-
-    #[test]
-    fn test_decode_connection_close_app_with_reason() {
-        // Type 0x1d, error_code=0x0a, reason_phrase_length=5, reason="error"
-        let mut buf = Bytes::from_static(&[0x1d, 0x0a, 0x05, b'e', b'r', b'r', b'o', b'r']);
-        assert_eq!(
-            Frame::decode(&mut buf),
-            Ok(Frame::ConnectionClose(
-                0x0a,
-                None,
-                5,
-                Bytes::from_static(b"error")
-            ))
-        );
-    }
-
-    #[test]
-    fn test_decode_connection_close_app_buffer_too_short() {
-        // Type 0x1d, error_code=0x0a, reason_phrase_length=5, but only 2 bytes of reason
-        let mut buf = Bytes::from_static(&[0x1d, 0x0a, 0x05, b'e', b'r']);
         assert_eq!(Frame::decode(&mut buf), Err(FrameError::BufferTooShort));
     }
 

--- a/src/quic/frames/mod.rs
+++ b/src/quic/frames/mod.rs
@@ -72,6 +72,17 @@ impl Frame {
                 let final_size = var_int::read(buf).ok_or(FrameError::InvalidVarInt)?;
                 Ok(Frame::ResetStream(stream_id, error_code, final_size))
             }
+            0x05 => {
+                if buf.remaining() == 0 {
+                    return Err(FrameError::InvalidVarInt);
+                }
+                let stream_id = var_int::read(buf).ok_or(FrameError::InvalidVarInt)?;
+                if buf.remaining() == 0 {
+                    return Err(FrameError::InvalidVarInt);
+                }
+                let error_code = var_int::read(buf).ok_or(FrameError::InvalidVarInt)?;
+                Ok(Frame::StopSending(stream_id, error_code))
+            }
             0x10 => {
                 if buf.is_empty() {
                     return Err(FrameError::InvalidVarInt);
@@ -285,6 +296,23 @@ mod tests {
     fn test_decode_reset_stream_frame_buffer_too_short() {
         // Type 0x04, stream_id=1 but missing error_code and final_size
         let mut buf = Bytes::from_static(&[0x04, 0x01]);
+        assert_eq!(Frame::decode(&mut buf), Err(FrameError::InvalidVarInt));
+    }
+
+    #[test]
+    fn test_decode_stop_sending_frame() {
+        // Type 0x05, stream_id=4, error_code=10
+        let mut buf = Bytes::from_static(&[0x05, 0x04, 0x0a]);
+        assert_eq!(
+            Frame::decode(&mut buf),
+            Ok(Frame::StopSending(4, 10))
+        );
+    }
+
+    #[test]
+    fn test_decode_stop_sending_frame_buffer_too_short() {
+        // Type 0x05, stream_id=4 but missing error_code
+        let mut buf = Bytes::from_static(&[0x05, 0x04]);
         assert_eq!(Frame::decode(&mut buf), Err(FrameError::InvalidVarInt));
     }
 

--- a/src/quic/frames/mod.rs
+++ b/src/quic/frames/mod.rs
@@ -140,6 +140,13 @@ impl Frame {
                 let max_streams = var_int::read(buf).ok_or(FrameError::InvalidVarInt)?;
                 Ok(Frame::StreamsBlocked(StreamDirection::BiDirectional, max_streams))
             }
+            0x17 => {
+                if buf.remaining() == 0 {
+                    return Err(FrameError::InvalidVarInt);
+                }
+                let max_streams = var_int::read(buf).ok_or(FrameError::InvalidVarInt)?;
+                Ok(Frame::StreamsBlocked(StreamDirection::UniDirectional, max_streams))
+            }
             0x19 => {
                 if buf.is_empty() {
                     return Err(FrameError::InvalidVarInt);
@@ -441,6 +448,23 @@ mod tests {
     fn test_decode_streams_blocked_bidi_frame_buffer_too_short() {
         // Type 0x16, missing max_streams
         let mut buf = Bytes::from_static(&[0x16]);
+        assert_eq!(Frame::decode(&mut buf), Err(FrameError::InvalidVarInt));
+    }
+
+    #[test]
+    fn test_decode_streams_blocked_uni_frame() {
+        // Type 0x17, max_streams=25
+        let mut buf = Bytes::from_static(&[0x17, 0x19]);
+        assert_eq!(
+            Frame::decode(&mut buf),
+            Ok(Frame::StreamsBlocked(StreamDirection::UniDirectional, 25))
+        );
+    }
+
+    #[test]
+    fn test_decode_streams_blocked_uni_frame_buffer_too_short() {
+        // Type 0x17, missing max_streams
+        let mut buf = Bytes::from_static(&[0x17]);
         assert_eq!(Frame::decode(&mut buf), Err(FrameError::InvalidVarInt));
     }
 

--- a/src/quic/frames/mod.rs
+++ b/src/quic/frames/mod.rs
@@ -122,6 +122,17 @@ impl Frame {
                 let maximum_data = var_int::read(buf).ok_or(FrameError::InvalidVarInt)?;
                 Ok(Frame::DataBlocked(maximum_data))
             }
+            0x15 => {
+                if buf.remaining() == 0 {
+                    return Err(FrameError::InvalidVarInt);
+                }
+                let stream_id = var_int::read(buf).ok_or(FrameError::InvalidVarInt)?;
+                if buf.remaining() == 0 {
+                    return Err(FrameError::InvalidVarInt);
+                }
+                let maximum_stream_data = var_int::read(buf).ok_or(FrameError::InvalidVarInt)?;
+                Ok(Frame::StreamDataBlocked(stream_id, maximum_stream_data))
+            }
             0x19 => {
                 if buf.is_empty() {
                     return Err(FrameError::InvalidVarInt);
@@ -389,6 +400,23 @@ mod tests {
     fn test_decode_max_streams_uni_frame_buffer_too_short() {
         // Type 0x13, missing max_streams
         let mut buf = Bytes::from_static(&[0x13]);
+        assert_eq!(Frame::decode(&mut buf), Err(FrameError::InvalidVarInt));
+    }
+
+    #[test]
+    fn test_decode_stream_data_blocked_frame() {
+        // Type 0x15, stream_id=5, maximum_stream_data=20
+        let mut buf = Bytes::from_static(&[0x15, 0x05, 0x14]);
+        assert_eq!(
+            Frame::decode(&mut buf),
+            Ok(Frame::StreamDataBlocked(5, 20))
+        );
+    }
+
+    #[test]
+    fn test_decode_stream_data_blocked_frame_buffer_too_short() {
+        // Type 0x15, stream_id=5 but missing maximum_stream_data
+        let mut buf = Bytes::from_static(&[0x15, 0x05]);
         assert_eq!(Frame::decode(&mut buf), Err(FrameError::InvalidVarInt));
     }
 

--- a/src/quic/frames/mod.rs
+++ b/src/quic/frames/mod.rs
@@ -106,14 +106,20 @@ impl Frame {
                     return Err(FrameError::InvalidVarInt);
                 }
                 let max_streams = var_int::read(buf).ok_or(FrameError::InvalidVarInt)?;
-                Ok(Frame::MaxStreams(StreamDirection::BiDirectional, max_streams))
+                Ok(Frame::MaxStreams(
+                    StreamDirection::BiDirectional,
+                    max_streams,
+                ))
             }
             0x13 => {
                 if buf.remaining() == 0 {
                     return Err(FrameError::InvalidVarInt);
                 }
                 let max_streams = var_int::read(buf).ok_or(FrameError::InvalidVarInt)?;
-                Ok(Frame::MaxStreams(StreamDirection::UniDirectional, max_streams))
+                Ok(Frame::MaxStreams(
+                    StreamDirection::UniDirectional,
+                    max_streams,
+                ))
             }
             0x14 => {
                 if buf.is_empty() {
@@ -138,14 +144,20 @@ impl Frame {
                     return Err(FrameError::InvalidVarInt);
                 }
                 let max_streams = var_int::read(buf).ok_or(FrameError::InvalidVarInt)?;
-                Ok(Frame::StreamsBlocked(StreamDirection::BiDirectional, max_streams))
+                Ok(Frame::StreamsBlocked(
+                    StreamDirection::BiDirectional,
+                    max_streams,
+                ))
             }
             0x17 => {
                 if buf.remaining() == 0 {
                     return Err(FrameError::InvalidVarInt);
                 }
                 let max_streams = var_int::read(buf).ok_or(FrameError::InvalidVarInt)?;
-                Ok(Frame::StreamsBlocked(StreamDirection::UniDirectional, max_streams))
+                Ok(Frame::StreamsBlocked(
+                    StreamDirection::UniDirectional,
+                    max_streams,
+                ))
             }
             0x19 => {
                 if buf.is_empty() {
@@ -336,10 +348,7 @@ mod tests {
     fn test_decode_reset_stream_frame() {
         // Type 0x04, stream_id=1, error_code=2, final_size=3
         let mut buf = Bytes::from_static(&[0x04, 0x01, 0x02, 0x03]);
-        assert_eq!(
-            Frame::decode(&mut buf),
-            Ok(Frame::ResetStream(1, 2, 3))
-        );
+        assert_eq!(Frame::decode(&mut buf), Ok(Frame::ResetStream(1, 2, 3)));
     }
 
     #[test]
@@ -353,10 +362,7 @@ mod tests {
     fn test_decode_stop_sending_frame() {
         // Type 0x05, stream_id=4, error_code=10
         let mut buf = Bytes::from_static(&[0x05, 0x04, 0x0a]);
-        assert_eq!(
-            Frame::decode(&mut buf),
-            Ok(Frame::StopSending(4, 10))
-        );
+        assert_eq!(Frame::decode(&mut buf), Ok(Frame::StopSending(4, 10)));
     }
 
     #[test]
@@ -370,10 +376,7 @@ mod tests {
     fn test_decode_max_stream_data_frame() {
         // Type 0x11, stream_id=8, maximum_stream_data=32
         let mut buf = Bytes::from_static(&[0x11, 0x08, 0x20]);
-        assert_eq!(
-            Frame::decode(&mut buf),
-            Ok(Frame::MaxStreamData(8, 32))
-        );
+        assert_eq!(Frame::decode(&mut buf), Ok(Frame::MaxStreamData(8, 32)));
     }
 
     #[test]
@@ -421,10 +424,7 @@ mod tests {
     fn test_decode_stream_data_blocked_frame() {
         // Type 0x15, stream_id=5, maximum_stream_data=20
         let mut buf = Bytes::from_static(&[0x15, 0x05, 0x14]);
-        assert_eq!(
-            Frame::decode(&mut buf),
-            Ok(Frame::StreamDataBlocked(5, 20))
-        );
+        assert_eq!(Frame::decode(&mut buf), Ok(Frame::StreamDataBlocked(5, 20)));
     }
 
     #[test]

--- a/src/quic/frames/mod.rs
+++ b/src/quic/frames/mod.rs
@@ -108,6 +108,13 @@ impl Frame {
                 let max_streams = var_int::read(buf).ok_or(FrameError::InvalidVarInt)?;
                 Ok(Frame::MaxStreams(StreamDirection::BiDirectional, max_streams))
             }
+            0x13 => {
+                if buf.remaining() == 0 {
+                    return Err(FrameError::InvalidVarInt);
+                }
+                let max_streams = var_int::read(buf).ok_or(FrameError::InvalidVarInt)?;
+                Ok(Frame::MaxStreams(StreamDirection::UniDirectional, max_streams))
+            }
             0x14 => {
                 if buf.is_empty() {
                     return Err(FrameError::InvalidVarInt);
@@ -365,6 +372,23 @@ mod tests {
     fn test_decode_max_streams_bidi_frame_buffer_too_short() {
         // Type 0x12, missing max_streams
         let mut buf = Bytes::from_static(&[0x12]);
+        assert_eq!(Frame::decode(&mut buf), Err(FrameError::InvalidVarInt));
+    }
+
+    #[test]
+    fn test_decode_max_streams_uni_frame() {
+        // Type 0x13, max_streams=32
+        let mut buf = Bytes::from_static(&[0x13, 0x20]);
+        assert_eq!(
+            Frame::decode(&mut buf),
+            Ok(Frame::MaxStreams(StreamDirection::UniDirectional, 32))
+        );
+    }
+
+    #[test]
+    fn test_decode_max_streams_uni_frame_buffer_too_short() {
+        // Type 0x13, missing max_streams
+        let mut buf = Bytes::from_static(&[0x13]);
         assert_eq!(Frame::decode(&mut buf), Err(FrameError::InvalidVarInt));
     }
 

--- a/src/quic/frames/mod.rs
+++ b/src/quic/frames/mod.rs
@@ -133,6 +133,13 @@ impl Frame {
                 let maximum_stream_data = var_int::read(buf).ok_or(FrameError::InvalidVarInt)?;
                 Ok(Frame::StreamDataBlocked(stream_id, maximum_stream_data))
             }
+            0x16 => {
+                if buf.remaining() == 0 {
+                    return Err(FrameError::InvalidVarInt);
+                }
+                let max_streams = var_int::read(buf).ok_or(FrameError::InvalidVarInt)?;
+                Ok(Frame::StreamsBlocked(StreamDirection::BiDirectional, max_streams))
+            }
             0x19 => {
                 if buf.is_empty() {
                     return Err(FrameError::InvalidVarInt);
@@ -417,6 +424,23 @@ mod tests {
     fn test_decode_stream_data_blocked_frame_buffer_too_short() {
         // Type 0x15, stream_id=5 but missing maximum_stream_data
         let mut buf = Bytes::from_static(&[0x15, 0x05]);
+        assert_eq!(Frame::decode(&mut buf), Err(FrameError::InvalidVarInt));
+    }
+
+    #[test]
+    fn test_decode_streams_blocked_bidi_frame() {
+        // Type 0x16, max_streams=10
+        let mut buf = Bytes::from_static(&[0x16, 0x0a]);
+        assert_eq!(
+            Frame::decode(&mut buf),
+            Ok(Frame::StreamsBlocked(StreamDirection::BiDirectional, 10))
+        );
+    }
+
+    #[test]
+    fn test_decode_streams_blocked_bidi_frame_buffer_too_short() {
+        // Type 0x16, missing max_streams
+        let mut buf = Bytes::from_static(&[0x16]);
         assert_eq!(Frame::decode(&mut buf), Err(FrameError::InvalidVarInt));
     }
 

--- a/src/quic/frames/mod.rs
+++ b/src/quic/frames/mod.rs
@@ -239,6 +239,41 @@ mod tests {
     }
 
     #[test]
+    fn test_decode_connection_close_app_empty_reason() {
+        // Type 0x1d, error_code=0x00, reason_phrase_length=0
+        let mut buf = Bytes::from_static(&[0x1d, 0x00, 0x00]);
+        assert_eq!(
+            Frame::decode(&mut buf),
+            Ok(Frame::ConnectionClose(0x00, None, 0, Bytes::new()))
+        );
+    }
+
+    #[test]
+    fn test_decode_connection_close_app_with_reason() {
+        // Type 0x1d, error_code=0x0a, reason_phrase_length=5, reason="error"
+        let mut buf = Bytes::from_static(&[0x1d, 0x0a, 0x05, b'e', b'r', b'r', b'o', b'r']);
+        assert_eq!(
+            Frame::decode(&mut buf),
+            Ok(Frame::ConnectionClose(
+                0x0a,
+                None,
+                5,
+                Bytes::from_static(b"error")
+            ))
+        );
+    }
+
+    #[test]
+    fn test_decode_connection_close_app_buffer_too_short() {
+        // Type 0x1d, error_code=0x0a, reason_phrase_length=5, but only 2 bytes of reason
+        let mut buf = Bytes::from_static(&[0x1d, 0x0a, 0x05, b'e', b'r']);
+        assert_eq!(
+            Frame::decode(&mut buf),
+            Err(FrameError::BufferTooShort)
+        );
+    }
+
+    #[test]
     fn test_decode_handshake_done_frame() {
         let mut buf = Bytes::from_static(&[0x1e]);
         assert_eq!(Frame::decode(&mut buf), Ok(Frame::HandshakeDone));

--- a/src/quic/frames/mod.rs
+++ b/src/quic/frames/mod.rs
@@ -101,6 +101,13 @@ impl Frame {
                 let maximum_stream_data = var_int::read(buf).ok_or(FrameError::InvalidVarInt)?;
                 Ok(Frame::MaxStreamData(stream_id, maximum_stream_data))
             }
+            0x12 => {
+                if buf.remaining() == 0 {
+                    return Err(FrameError::InvalidVarInt);
+                }
+                let max_streams = var_int::read(buf).ok_or(FrameError::InvalidVarInt)?;
+                Ok(Frame::MaxStreams(StreamDirection::BiDirectional, max_streams))
+            }
             0x14 => {
                 if buf.is_empty() {
                     return Err(FrameError::InvalidVarInt);
@@ -341,6 +348,23 @@ mod tests {
     fn test_decode_max_stream_data_frame_buffer_too_short() {
         // Type 0x11, stream_id=8 but missing maximum_stream_data
         let mut buf = Bytes::from_static(&[0x11, 0x08]);
+        assert_eq!(Frame::decode(&mut buf), Err(FrameError::InvalidVarInt));
+    }
+
+    #[test]
+    fn test_decode_max_streams_bidi_frame() {
+        // Type 0x12, max_streams=16
+        let mut buf = Bytes::from_static(&[0x12, 0x10]);
+        assert_eq!(
+            Frame::decode(&mut buf),
+            Ok(Frame::MaxStreams(StreamDirection::BiDirectional, 16))
+        );
+    }
+
+    #[test]
+    fn test_decode_max_streams_bidi_frame_buffer_too_short() {
+        // Type 0x12, missing max_streams
+        let mut buf = Bytes::from_static(&[0x12]);
         assert_eq!(Frame::decode(&mut buf), Err(FrameError::InvalidVarInt));
     }
 

--- a/src/quic/frames/mod.rs
+++ b/src/quic/frames/mod.rs
@@ -1,4 +1,6 @@
 #![allow(dead_code)]
+pub mod validate;
+
 use bytes::{Buf, Bytes};
 use thiserror::Error;
 
@@ -29,6 +31,13 @@ pub enum Frame {
     Padding,
     Ping,
     HandshakeDone,
+    Stream {
+        id: VarInt,
+        offset: VarInt,
+        fin: bool,
+        len: VarInt,
+        data: Bytes,
+    },
     MaxData(VarInt),
     DataBlocked(VarInt),
     RetireConnectionId(VarInt),
@@ -57,6 +66,43 @@ impl Frame {
         match frame_type {
             0x00 => Ok(Frame::Padding),
             0x01 => Ok(Frame::Ping),
+            0x08..=0x0f => {
+                let fin = (frame_type & 0x01) != 0;
+                let len_flag = (frame_type & 0x02) != 0;
+                let off_flag = (frame_type & 0x04) != 0;
+
+                if buf.remaining() == 0 {
+                    return Err(FrameError::InvalidVarInt);
+                }
+                let stream_id = var_int::read(buf).ok_or(FrameError::InvalidVarInt)?;
+                let offset = if off_flag {
+                    if buf.remaining() == 0 {
+                        return Err(FrameError::InvalidVarInt);
+                    }
+                    var_int::read(buf).ok_or(FrameError::InvalidVarInt)?
+                } else {
+                    0
+                };
+                let len = if len_flag {
+                    if buf.remaining() == 0 {
+                        return Err(FrameError::InvalidVarInt);
+                    }
+                    var_int::read(buf).ok_or(FrameError::InvalidVarInt)?
+                } else {
+                    buf.remaining() as VarInt
+                };
+                if len > buf.remaining() as VarInt {
+                    return Err(FrameError::BufferTooShort);
+                }
+                let data = buf.copy_to_bytes(len as usize);
+                Ok(Frame::Stream {
+                    id: stream_id,
+                    offset,
+                    fin,
+                    len,
+                    data,
+                })
+            }
             0x04 => {
                 if buf.remaining() == 0 {
                     return Err(FrameError::InvalidVarInt);
@@ -243,6 +289,57 @@ mod tests {
     fn test_decode_ping_frame() {
         let mut buf = Bytes::from_static(&[0x01]);
         assert_eq!(Frame::decode(&mut buf), Ok(Frame::Ping));
+    }
+
+    #[test]
+    fn test_decode_stream_frame_no_off_no_len() {
+        let mut buf = Bytes::from_static(&[0x08, 0x05, b'H', b'i']);
+        assert_eq!(
+            Frame::decode(&mut buf),
+            Ok(Frame::Stream {
+                id: 5,
+                offset: 0,
+                fin: false,
+                len: 2,
+                data: Bytes::from_static(b"Hi"),
+            })
+        );
+    }
+
+    #[test]
+    fn test_decode_stream_frame_with_off_and_len() {
+        let mut buf = Bytes::from_static(&[0x0e, 0x02, 0x04, 0x03, b'a', b'b', b'c']);
+        assert_eq!(
+            Frame::decode(&mut buf),
+            Ok(Frame::Stream {
+                id: 2,
+                offset: 4,
+                fin: false,
+                len: 3,
+                data: Bytes::from_static(b"abc"),
+            })
+        );
+    }
+
+    #[test]
+    fn test_decode_stream_frame_with_fin_and_len() {
+        let mut buf = Bytes::from_static(&[0x0b, 0x01, 0x01, b'Z']);
+        assert_eq!(
+            Frame::decode(&mut buf),
+            Ok(Frame::Stream {
+                id: 1,
+                offset: 0,
+                fin: true,
+                len: 1,
+                data: Bytes::from_static(b"Z"),
+            })
+        );
+    }
+
+    #[test]
+    fn test_decode_stream_frame_buffer_too_short_for_len() {
+        let mut buf = Bytes::from_static(&[0x0a, 0x01, 0x03, b'a']);
+        assert_eq!(Frame::decode(&mut buf), Err(FrameError::BufferTooShort));
     }
 
     #[test]

--- a/src/quic/frames/mod.rs
+++ b/src/quic/frames/mod.rs
@@ -207,6 +207,38 @@ mod tests {
     }
 
     #[test]
+    fn test_decode_connection_close_quic_empty_reason() {
+        // Type 0x1c, error_code=0x00, frame_type=0x00, reason_phrase_length=0
+        let mut buf = Bytes::from_static(&[0x1c, 0x00, 0x00, 0x00]);
+        assert_eq!(
+            Frame::decode(&mut buf),
+            Ok(Frame::ConnectionClose(0x00, Some(0x00), 0, Bytes::new()))
+        );
+    }
+
+    #[test]
+    fn test_decode_connection_close_quic_with_reason() {
+        // Type 0x1c, error_code=0x0a, frame_type=0x01, reason_phrase_length=5, reason="error"
+        let mut buf = Bytes::from_static(&[0x1c, 0x0a, 0x01, 0x05, b'e', b'r', b'r', b'o', b'r']);
+        assert_eq!(
+            Frame::decode(&mut buf),
+            Ok(Frame::ConnectionClose(
+                0x0a,
+                Some(0x01),
+                5,
+                Bytes::from_static(b"error")
+            ))
+        );
+    }
+
+    #[test]
+    fn test_decode_connection_close_quic_buffer_too_short() {
+        // Type 0x1c, error_code=0x0a, frame_type=0x01, reason_phrase_length=5, but only 2 bytes of reason
+        let mut buf = Bytes::from_static(&[0x1c, 0x0a, 0x01, 0x05, b'e', b'r']);
+        assert_eq!(Frame::decode(&mut buf), Err(FrameError::BufferTooShort));
+    }
+
+    #[test]
     fn test_decode_handshake_done_frame() {
         let mut buf = Bytes::from_static(&[0x1e]);
         assert_eq!(Frame::decode(&mut buf), Ok(Frame::HandshakeDone));

--- a/src/quic/frames/mod.rs
+++ b/src/quic/frames/mod.rs
@@ -160,6 +160,7 @@ mod tests {
     #[test]
     fn test_decode_path_challenge() {
         let mut buf = Bytes::from_static(&[0x1a, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08]);
+        let mut buf = Bytes::from_static(&[0x1a, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08]);
         assert_eq!(
             Frame::decode(&mut buf),
             Ok(Frame::PathChallenge([
@@ -171,21 +172,6 @@ mod tests {
     #[test]
     fn test_decode_path_challenge_buffer_too_short() {
         let mut buf = Bytes::from_static(&[0x1a, 0x01, 0x02]);
-        assert_eq!(
-            Frame::decode(&mut buf),
-            Ok(Frame::ConnectionClose(
-                0x0a,
-                None,
-                5,
-                Bytes::from_static(b"error")
-            ))
-        );
-    }
-
-    #[test]
-    fn test_decode_connection_close_app_buffer_too_short() {
-        // Type 0x1d, error_code=0x0a, reason_phrase_length=5, but only 2 bytes of reason
-        let mut buf = Bytes::from_static(&[0x1d, 0x0a, 0x05, b'e', b'r']);
         assert_eq!(Frame::decode(&mut buf), Err(FrameError::BufferTooShort));
     }
 
@@ -267,10 +253,7 @@ mod tests {
     fn test_decode_connection_close_app_buffer_too_short() {
         // Type 0x1d, error_code=0x0a, reason_phrase_length=5, but only 2 bytes of reason
         let mut buf = Bytes::from_static(&[0x1d, 0x0a, 0x05, b'e', b'r']);
-        assert_eq!(
-            Frame::decode(&mut buf),
-            Err(FrameError::BufferTooShort)
-        );
+        assert_eq!(Frame::decode(&mut buf), Err(FrameError::BufferTooShort));
     }
 
     #[test]

--- a/src/quic/frames/mod.rs
+++ b/src/quic/frames/mod.rs
@@ -90,6 +90,17 @@ impl Frame {
                 let maximum_data = var_int::read(buf).ok_or(FrameError::InvalidVarInt)?;
                 Ok(Frame::MaxData(maximum_data))
             }
+            0x11 => {
+                if buf.remaining() == 0 {
+                    return Err(FrameError::InvalidVarInt);
+                }
+                let stream_id = var_int::read(buf).ok_or(FrameError::InvalidVarInt)?;
+                if buf.remaining() == 0 {
+                    return Err(FrameError::InvalidVarInt);
+                }
+                let maximum_stream_data = var_int::read(buf).ok_or(FrameError::InvalidVarInt)?;
+                Ok(Frame::MaxStreamData(stream_id, maximum_stream_data))
+            }
             0x14 => {
                 if buf.is_empty() {
                     return Err(FrameError::InvalidVarInt);
@@ -313,6 +324,23 @@ mod tests {
     fn test_decode_stop_sending_frame_buffer_too_short() {
         // Type 0x05, stream_id=4 but missing error_code
         let mut buf = Bytes::from_static(&[0x05, 0x04]);
+        assert_eq!(Frame::decode(&mut buf), Err(FrameError::InvalidVarInt));
+    }
+
+    #[test]
+    fn test_decode_max_stream_data_frame() {
+        // Type 0x11, stream_id=8, maximum_stream_data=32
+        let mut buf = Bytes::from_static(&[0x11, 0x08, 0x20]);
+        assert_eq!(
+            Frame::decode(&mut buf),
+            Ok(Frame::MaxStreamData(8, 32))
+        );
+    }
+
+    #[test]
+    fn test_decode_max_stream_data_frame_buffer_too_short() {
+        // Type 0x11, stream_id=8 but missing maximum_stream_data
+        let mut buf = Bytes::from_static(&[0x11, 0x08]);
         assert_eq!(Frame::decode(&mut buf), Err(FrameError::InvalidVarInt));
     }
 

--- a/src/quic/frames/validate.rs
+++ b/src/quic/frames/validate.rs
@@ -1,0 +1,199 @@
+use thiserror::Error;
+
+type VarInt = u64;
+
+#[derive(Error, Debug, PartialEq)]
+pub enum FrameValidationError {
+    #[error("MAX_STREAMS value decreased (current={current}, new={new})")]
+    MaxStreamsDecreased { current: VarInt, new: VarInt },
+    #[error("MAX_STREAM_DATA value decreased (current={current}, new={new})")]
+    MaxStreamDataDecreased { current: VarInt, new: VarInt },
+    #[error("Final size changed (current={current}, new={new})")]
+    FinalSizeChanged { current: VarInt, new: VarInt },
+    #[error(
+        "Final size below received data (final_size={final_size}, observed_end={observed_end})"
+    )]
+    FinalSizeBelowReceived {
+        final_size: VarInt,
+        observed_end: VarInt,
+    },
+    #[error("MAX_STREAMS above limit (value={value}, limit={limit})")]
+    MaxStreamsAboveLimit { value: VarInt, limit: VarInt },
+    #[error("MAX_STREAM_DATA above limit (value={value}, limit={limit})")]
+    MaxStreamDataAboveLimit { value: VarInt, limit: VarInt },
+    #[error("STREAMS_BLOCKED above limit (value={value}, limit={limit})")]
+    StreamsBlockedAboveLimit { value: VarInt, limit: VarInt },
+    #[error("STREAM_DATA_BLOCKED above limit (value={value}, limit={limit})")]
+    StreamDataBlockedAboveLimit { value: VarInt, limit: VarInt },
+}
+
+pub fn validate_max_streams_monotonic(
+    current: Option<VarInt>,
+    new: VarInt,
+) -> Result<(), FrameValidationError> {
+    if let Some(current_value) = current
+        && new < current_value
+    {
+        return Err(FrameValidationError::MaxStreamsDecreased {
+            current: current_value,
+            new,
+        });
+    }
+    Ok(())
+}
+
+pub fn validate_max_stream_data_monotonic(
+    current: Option<VarInt>,
+    new: VarInt,
+) -> Result<(), FrameValidationError> {
+    if let Some(current_value) = current
+        && new < current_value
+    {
+        return Err(FrameValidationError::MaxStreamDataDecreased {
+            current: current_value,
+            new,
+        });
+    }
+    Ok(())
+}
+
+pub fn validate_final_size(
+    current: Option<VarInt>,
+    new: VarInt,
+    observed_end: Option<VarInt>,
+) -> Result<(), FrameValidationError> {
+    if let Some(current_value) = current
+        && new != current_value
+    {
+        return Err(FrameValidationError::FinalSizeChanged {
+            current: current_value,
+            new,
+        });
+    }
+    if let Some(observed) = observed_end
+        && new < observed
+    {
+        return Err(FrameValidationError::FinalSizeBelowReceived {
+            final_size: new,
+            observed_end: observed,
+        });
+    }
+    Ok(())
+}
+
+pub fn validate_max_streams_upper_bound(
+    value: VarInt,
+    limit: VarInt,
+) -> Result<(), FrameValidationError> {
+    if value > limit {
+        return Err(FrameValidationError::MaxStreamsAboveLimit { value, limit });
+    }
+    Ok(())
+}
+
+pub fn validate_max_stream_data_upper_bound(
+    value: VarInt,
+    limit: VarInt,
+) -> Result<(), FrameValidationError> {
+    if value > limit {
+        return Err(FrameValidationError::MaxStreamDataAboveLimit { value, limit });
+    }
+    Ok(())
+}
+
+pub fn validate_streams_blocked(value: VarInt, limit: VarInt) -> Result<(), FrameValidationError> {
+    if value > limit {
+        return Err(FrameValidationError::StreamsBlockedAboveLimit { value, limit });
+    }
+    Ok(())
+}
+
+pub fn validate_stream_data_blocked(
+    value: VarInt,
+    limit: VarInt,
+) -> Result<(), FrameValidationError> {
+    if value > limit {
+        return Err(FrameValidationError::StreamDataBlockedAboveLimit { value, limit });
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_validate_max_streams_monotonic_ok() {
+        assert_eq!(validate_max_streams_monotonic(Some(10), 10), Ok(()));
+        assert_eq!(validate_max_streams_monotonic(Some(10), 12), Ok(()));
+    }
+
+    #[test]
+    fn test_validate_max_streams_monotonic_decreased() {
+        assert_eq!(
+            validate_max_streams_monotonic(Some(10), 9),
+            Err(FrameValidationError::MaxStreamsDecreased {
+                current: 10,
+                new: 9
+            })
+        );
+    }
+
+    #[test]
+    fn test_validate_max_stream_data_monotonic_decreased() {
+        assert_eq!(
+            validate_max_stream_data_monotonic(Some(5), 4),
+            Err(FrameValidationError::MaxStreamDataDecreased { current: 5, new: 4 })
+        );
+    }
+
+    #[test]
+    fn test_validate_final_size_changed() {
+        assert_eq!(
+            validate_final_size(Some(10), 12, None),
+            Err(FrameValidationError::FinalSizeChanged {
+                current: 10,
+                new: 12
+            })
+        );
+    }
+
+    #[test]
+    fn test_validate_final_size_below_received() {
+        assert_eq!(
+            validate_final_size(None, 5, Some(6)),
+            Err(FrameValidationError::FinalSizeBelowReceived {
+                final_size: 5,
+                observed_end: 6
+            })
+        );
+    }
+
+    #[test]
+    fn test_validate_max_streams_upper_bound() {
+        assert_eq!(validate_max_streams_upper_bound(10, 10), Ok(()));
+        assert_eq!(
+            validate_max_streams_upper_bound(11, 10),
+            Err(FrameValidationError::MaxStreamsAboveLimit {
+                value: 11,
+                limit: 10
+            })
+        );
+    }
+
+    #[test]
+    fn test_validate_streams_blocked_upper_bound() {
+        assert_eq!(
+            validate_streams_blocked(5, 4),
+            Err(FrameValidationError::StreamsBlockedAboveLimit { value: 5, limit: 4 })
+        );
+    }
+
+    #[test]
+    fn test_validate_stream_data_blocked_upper_bound() {
+        assert_eq!(
+            validate_stream_data_blocked(9, 8),
+            Err(FrameValidationError::StreamDataBlockedAboveLimit { value: 9, limit: 8 })
+        );
+    }
+}


### PR DESCRIPTION
Add decoding support for QUIC stream control frames:

- **ResetStream (0x04)**: Decodes stream_id, error_code, and final_size fields
- **StopSending (0x05)**: Decodes stream_id and error_code fields
- **MaxStreamData (0x11)**: Decodes stream_id and maximum_stream_data fields
- **MaxStreams Bidirectional (0x12)**: Decodes max_streams with BiDirectional direction
- **MaxStreams Unidirectional (0x13)**: Decodes max_streams with UniDirectional direction
- **StreamDataBlocked (0x15)**: Decodes stream_id and maximum_stream_data fields
- **StreamsBlocked Bidirectional (0x16)**: Decodes max_streams with BiDirectional direction
- **StreamsBlocked Unidirectional (0x17)**: Decodes max_streams with UniDirectional direction

Each frame type includes success and buffer-too-short test cases (16 new tests total).