### PR TITLE
Housekeeping: refine Decode trait and fix version negotiation typo

### DIFF
--- a/src/quic/packets/long_header.rs
+++ b/src/quic/packets/long_header.rs
@@ -49,7 +49,9 @@ const PACKET_TYPE_RETRY: u8 = 0x30;
 const RETRY_INTEGRITY_TAG_LENGTH: usize = 16;
 
 impl Decode for LongHeaderPacket {
-    fn decode(mut buf: Bytes) -> Result<Self, PacketError> {
+    type Context = ();
+
+    fn decode(mut buf: Bytes, _ctx: Self::Context) -> Result<Self, PacketError> {
         if buf.is_empty() {
             return Err(PacketError::BufferTooShort);
         }
@@ -173,7 +175,7 @@ mod tests {
     fn test_returns_buffer_too_short_when_buffer_is_empty() {
         let buf = Bytes::from_static(&[]);
         assert!(matches!(
-            LongHeaderPacket::decode(buf),
+            LongHeaderPacket::decode(buf, ()),
             Err(PacketError::BufferTooShort)
         ));
     }
@@ -182,7 +184,7 @@ mod tests {
     fn test_returns_invalid_header_when_not_long_header() {
         let buf = Bytes::from_static(&[0b01000000, 0, 0, 0, 1]);
         assert!(matches!(
-            LongHeaderPacket::decode(buf),
+            LongHeaderPacket::decode(buf, ()),
             Err(PacketError::InvalidPacketHeader)
         ));
     }
@@ -191,7 +193,7 @@ mod tests {
     fn test_returns_invalid_header_when_fixed_bit_not_set() {
         let buf = Bytes::from_static(&[0b10000000, 0, 0, 0, 1]);
         assert!(matches!(
-            LongHeaderPacket::decode(buf),
+            LongHeaderPacket::decode(buf, ()),
             Err(PacketError::InvalidPacketHeader)
         ));
     }
@@ -207,7 +209,7 @@ mod tests {
         buf.put(&[0u8; 10][..]);
 
         assert!(matches!(
-            LongHeaderPacket::decode(buf.freeze()),
+            LongHeaderPacket::decode(buf.freeze(), ()),
             Err(PacketError::BufferTooShort)
         ));
     }
@@ -224,7 +226,7 @@ mod tests {
         // No retry token, just 16-byte integrity tag
         buf.put(&[0xAA; 16][..]);
 
-        let packet = LongHeaderPacket::decode(buf.freeze()).unwrap();
+        let packet = LongHeaderPacket::decode(buf.freeze(), ()).unwrap();
         match packet {
             LongHeaderPacket::Retry {
                 version,
@@ -256,7 +258,7 @@ mod tests {
         buf.put(&b"my-retry-token"[..]); // 14-byte retry token
         buf.put(&[0xBB; 16][..]); // 16-byte integrity tag
 
-        let packet = LongHeaderPacket::decode(buf.freeze()).unwrap();
+        let packet = LongHeaderPacket::decode(buf.freeze(), ()).unwrap();
         match packet {
             LongHeaderPacket::Retry {
                 version,
@@ -285,7 +287,7 @@ mod tests {
         buf.put_u8(0x34);
         buf.put(&b"PIN"[..]);
 
-        let packet = LongHeaderPacket::decode(buf.freeze()).unwrap();
+        let packet = LongHeaderPacket::decode(buf.freeze(), ()).unwrap();
         match packet {
             LongHeaderPacket::Initial {
                 version,
@@ -310,7 +312,7 @@ mod tests {
     fn test_returns_invalid_header_when_header_is_not_0rtt() {
         let buf = Bytes::from_static(&[0b01000000, 0, 0, 0, 1]);
         assert!(matches!(
-            LongHeaderPacket::decode(buf),
+            LongHeaderPacket::decode(buf, ()),
             Err(PacketError::InvalidPacketHeader)
         ));
     }
@@ -328,7 +330,7 @@ mod tests {
         buf.put(&b"\x09\x0A"[..]);
         buf.put(&b"PING"[..]);
 
-        let packet = LongHeaderPacket::decode(buf.freeze()).unwrap();
+        let packet = LongHeaderPacket::decode(buf.freeze(), ()).unwrap();
         match packet {
             LongHeaderPacket::ZeroRtt {
                 version,
@@ -354,7 +356,7 @@ mod tests {
     fn test_returns_invalid_header_when_header_is_not_handshake() {
         let buf = Bytes::from_static(&[0b01000000, 0, 0, 0, 1]);
         assert!(matches!(
-            LongHeaderPacket::decode(buf),
+            LongHeaderPacket::decode(buf, ()),
             Err(PacketError::InvalidPacketHeader)
         ));
     }
@@ -372,7 +374,7 @@ mod tests {
         buf.put(&b"\x09\x0A"[..]);
         buf.put(&b"PING"[..]);
 
-        let packet = LongHeaderPacket::decode(buf.freeze()).unwrap();
+        let packet = LongHeaderPacket::decode(buf.freeze(), ()).unwrap();
         match packet {
             LongHeaderPacket::Handshake {
                 version,

--- a/src/quic/packets/mod.rs
+++ b/src/quic/packets/mod.rs
@@ -4,7 +4,7 @@ use thiserror::Error;
 
 pub mod long_header;
 pub mod short_header;
-pub mod version_negotation;
+pub mod version_negotiation;
 
 #[derive(Error, Debug)]
 pub enum PacketError {
@@ -18,6 +18,15 @@ pub enum PacketError {
     UnexpectedPacketType,
 }
 
+/// Decode a packet type from a byte buffer.
+///
+/// Some packet forms need extra connection state to decode. Short-header
+/// packets, for example, omit the DCID length from the wire format, so the
+/// caller must supply it via [`Self::Context`]. Types that need no extra
+/// context use `()` as their context.
 pub trait Decode: Sized {
-    fn decode(buf: Bytes) -> Result<Self, PacketError>;
+    /// Additional context required for decoding. Use `()` when none is needed.
+    type Context;
+
+    fn decode(buf: Bytes, ctx: Self::Context) -> Result<Self, PacketError>;
 }

--- a/src/quic/packets/short_header.rs
+++ b/src/quic/packets/short_header.rs
@@ -1,5 +1,5 @@
 #![allow(dead_code)]
-use super::PacketError;
+use super::{Decode, PacketError};
 use bytes::{Buf, Bytes};
 
 /// A 1-RTT Short Header packet per RFC 9000 Section 17.3.
@@ -15,8 +15,12 @@ const HEADER_FORM_BIT: u8 = 0x80;
 const FIXED_BIT: u8 = 0x40;
 const PACKET_NUMBER_LENGTH_MASK: u8 = 0x03;
 
-impl ShortHeaderPacket {
-    pub fn decode(mut buf: Bytes, dcid_len: usize) -> Result<Self, PacketError> {
+impl Decode for ShortHeaderPacket {
+    /// Destination connection ID length, which is not present on the wire for
+    /// short-header packets and must come from connection state (RFC 9000 §17.3).
+    type Context = usize;
+
+    fn decode(mut buf: Bytes, dcid_len: Self::Context) -> Result<Self, PacketError> {
         if buf.is_empty() {
             return Err(PacketError::BufferTooShort);
         }

--- a/src/quic/packets/version_negotiation.rs
+++ b/src/quic/packets/version_negotiation.rs
@@ -22,7 +22,12 @@ impl Default for VersionNegotiationPacket {
 }
 
 impl Decode for VersionNegotiationPacket {
-    fn decode(mut buf: Bytes) -> Result<VersionNegotiationPacket, PacketError> {
+    type Context = ();
+
+    fn decode(
+        mut buf: Bytes,
+        _ctx: Self::Context,
+    ) -> Result<VersionNegotiationPacket, PacketError> {
         if buf.len() < 7 {
             return Err(PacketError::BufferTooShort);
         }
@@ -75,7 +80,7 @@ mod tests {
     fn test_decode_too_short() {
         let buf = Bytes::from_static(&[0u8; 5]);
         assert!(matches!(
-            VersionNegotiationPacket::decode(buf),
+            VersionNegotiationPacket::decode(buf, ()),
             Err(PacketError::BufferTooShort)
         ));
     }
@@ -84,7 +89,7 @@ mod tests {
     fn test_decode_not_long_header() {
         let buf = Bytes::from_static(&[0x7Fu8; 10]);
         assert!(matches!(
-            VersionNegotiationPacket::decode(buf),
+            VersionNegotiationPacket::decode(buf, ()),
             Err(PacketError::InvalidPacketHeader)
         ));
     }
@@ -93,7 +98,7 @@ mod tests {
     fn test_decode_not_version_negotiation() {
         let buf = Bytes::from_static(&[0x80u8, 0, 0, 0, 1, 0, 0, 0, 0]);
         assert!(matches!(
-            VersionNegotiationPacket::decode(buf),
+            VersionNegotiationPacket::decode(buf, ()),
             Err(PacketError::UnexpectedPacketType)
         ));
     }
@@ -110,7 +115,7 @@ mod tests {
         buf.put_u32(1_u32);
         buf.put_u32(2_u32);
 
-        let packet = VersionNegotiationPacket::decode(buf.freeze()).unwrap();
+        let packet = VersionNegotiationPacket::decode(buf.freeze(), ()).unwrap();
         assert_eq!(packet.version, 0);
         assert_eq!(packet.destination_connection_id.len(), 8);
         assert_eq!(packet.source_connection_id.len(), 8);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #17.

## Summary
Addresses the housekeeping items identified during code review of the QUIC packet/frame decoding work so far.

## Changes
1. **Filename typo**: renamed `version_negotation.rs` → `version_negotiation.rs` and updated the `mod` declaration.
2. **Decode trait refinement**: added an associated `Context` type so packet forms that need connection state can share the same trait:
   - `LongHeaderPacket` / `VersionNegotiationPacket` use `Context = ()`
   - `ShortHeaderPacket` now implements `Decode` with `Context = usize` (DCID length, which is not on the wire per RFC 9000 §17.3)
3. **PathChallenge / PathResponse**: already use `[u8; 8]` on `main` (from #23), so no further change was needed.

## Testing
- `cargo test` — 53 passed
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f7a6b-48e8-7367-8545-1a96ad8a093c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f7a6b-48e8-7367-8545-1a96ad8a093c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

